### PR TITLE
Add alternate encodings for PCA inputs

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,13 @@
 # CHANGELOG
 
+## 2.1.0
+
+### Features
+
+* Add alternate encodings of nucleotide sequences for PCA in `pathogen-embed` ([#23][])
+
+[#23]: https://github.com/blab/pathogen-embed/pull/23
+
 ## 2.0.0
 
 ### Major Changes

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ with open("README.md", "r", encoding="utf-8") as fh:
 
 setup(
     name='pathogen-embed',
-    version='2.0.0',
+    version='2.1.0',
     description='Reduced dimension embeddings for pathogen sequences',
     url='https://github.com/blab/pathogen-embed/',
     author='Sravani Nanduri <nandsra@cs.washington.edu> , John Huddleston <huddlej@gmail.com>',

--- a/src/pathogen_embed/__init__.py
+++ b/src/pathogen_embed/__init__.py
@@ -6,6 +6,6 @@ Reduced dimension embeddings for pathogen sequences.
 
 from .__main__ import make_parser_cluster, make_parser_distance, make_parser_embed
 
-__version__ = "2.0.0"
+__version__ = "2.1.0"
 __author__ = 'Sravani Nanduri, John Huddleston'
 __credits__ = 'Bedford Lab, Vaccine and Infectious Disease Division, Fred Hutchinson Cancer Center, Seattle, WA, USA'

--- a/src/pathogen_embed/__main__.py
+++ b/src/pathogen_embed/__main__.py
@@ -33,6 +33,7 @@ def make_parser_embed():
     )
 
     pca = subparsers.add_parser("pca", description="Principal Component Analysis", formatter_class=argparse.ArgumentDefaultsHelpFormatter)
+    pca.add_argument("--encoding", default="integer", choices=["integer", "genotype", "simplex"], help="method to use to encode the given sequence alignment as a matrix for input to PCA")
     pca.add_argument("--components", default=10, type=int, help="the number of components for PCA")
     pca.add_argument("--explained-variance", help="the path for the CSV explained variance for each component")
 

--- a/src/pathogen_embed/__main__.py
+++ b/src/pathogen_embed/__main__.py
@@ -33,7 +33,7 @@ def make_parser_embed():
     )
 
     pca = subparsers.add_parser("pca", description="Principal Component Analysis", formatter_class=argparse.ArgumentDefaultsHelpFormatter)
-    pca.add_argument("--encoding", default="integer", choices=["integer", "genotype", "simplex"], help="method to use to encode the given sequence alignment as a matrix for input to PCA")
+    pca.add_argument("--encoding", default="integer", choices=["integer", "genotype", "simplex", "biallelic"], help="method to use to encode the given sequence alignment as a matrix for input to PCA")
     pca.add_argument("--components", default=10, type=int, help="the number of components for PCA")
     pca.add_argument("--explained-variance", help="the path for the CSV explained variance for each component")
 

--- a/src/pathogen_embed/__main__.py
+++ b/src/pathogen_embed/__main__.py
@@ -33,11 +33,22 @@ def make_parser_embed():
     )
 
     pca = subparsers.add_parser("pca", description="Principal Component Analysis", formatter_class=argparse.ArgumentDefaultsHelpFormatter)
-    pca.add_argument("--encoding", default="integer", choices=["integer", "genotype", "simplex", "biallelic"], help="method to use to encode the given sequence alignment as a matrix for input to PCA")
+    pca.add_argument(
+        "--encoding",
+        default="integer",
+        choices=["integer", "genotype", "simplex", "biallelic"],
+        help="""method to use to encode the given sequence alignment as a matrix for input to PCA.
+        The "integer" encoding maps each ACGT nucleotide character to an integer (A to 1, G to 2, C to 3, T to 4) and all other characters to 5.
+        The "genotype" encoding maps each ACGT nucleotide to a one-hot binary encoding (A to [1, 0, 0, 0], C to [0, 1, 0, 0], etc.) and all other characters to [0, 0, 0, 0].
+        The "simplex" encoding maps each ACGT nucleotide to a simplex space as described in Stormo 2011 (A to [1, -1, -1], C to [-1, 1, -1], etc.) and all other characters to [0, 0, 0].
+        The "biallelic" encoding identifies all biallelic positions in the input alignment, encodes each allele that matches the first ("reference") sequence as a 0 and each alternate allele as a 1.
+        """
+    )
     pca.add_argument("--components", default=10, type=int, help="the number of components for PCA")
     pca.add_argument("--explained-variance", help="the path for the CSV explained variance for each component")
 
     tsne = subparsers.add_parser("t-sne", description="t-distributed Stochastic Neighborhood Embedding", formatter_class=argparse.ArgumentDefaultsHelpFormatter)
+    tsne.add_argument("--pca-encoding", default="integer", choices=["integer", "genotype", "simplex", "biallelic"], help="method to use to encode the given sequence alignment as a matrix for input the PCA embedding that initializes the t-SNE embedding. See help for the PCA embedding subcommand for more details.")
     tsne.add_argument("--components", default=2, type=int, help="the number of components for t-SNE")
     tsne.add_argument("--perplexity", default=30.0, type=float, help="The perplexity is related to the number of nearest neighbors. Because of this, the size of the dataset is proportional to the best perplexity value (large dataset -> large perplexity). Values between 5 and 50 work best. The default value is the value consistently the best for pathogen analyses, results from an exhaustive grid search.")
     tsne.add_argument("--learning-rate", default="auto", type=autoOrFloat, help="The learning rate for t-SNE is usually between 10.0 and 1000.0. Values out of these bounds may create innacurate results. The default value is the value consistently the best for pathogen analyses, results from an exhaustive grid search.")

--- a/src/pathogen_embed/pathogen_embed.py
+++ b/src/pathogen_embed/pathogen_embed.py
@@ -406,7 +406,7 @@ def embed(args):
 
     # If we have alignments but no distance matrices and we need distances for
     # the method, calculate distances on the fly.
-    if args.alignment is not None and distance_matrix is None and args.command != "pca":
+    if args.alignment is not None and distance_matrix is None and (args.command != "pca" or args.output_pairwise_distance_figure):
         for alignment in args.alignment:
             # Calculate a distance matrix on the fly and sort the matrix
             # alphabetically by sequence name, so we can safely sum values

--- a/src/pathogen_embed/pathogen_embed.py
+++ b/src/pathogen_embed/pathogen_embed.py
@@ -455,19 +455,24 @@ def embed(args):
 
     # Use PCA as its own embedding or as an initialization for t-SNE.
     if args.command == "pca" or args.command == "t-sne":
+        if args.command == "pca":
+            encoding = args.encoding
+        else:
+            encoding = args.pca_encoding
+
         genomes_dfs = []
         column_offset = 0
         for alignment in args.alignment:
-            if args.encoding == "integer":
+            if encoding == "integer":
                 genomes_df = encode_alignment_for_pca_by_integer(alignment)
-            elif args.encoding == "genotype":
+            elif encoding == "genotype":
                 genomes_df = encode_alignment_for_pca_by_genotype(alignment)
-            elif args.encoding == "simplex":
+            elif encoding == "simplex":
                 genomes_df = encode_alignment_for_pca_by_simplex(alignment)
-            elif args.encoding == "biallelic":
+            elif encoding == "biallelic":
                 genomes_df = encode_alignment_for_pca_by_biallelic(alignment)
             else:
-                raise NotImplementedError(f"PCA encoding by '{args.encoding}' is not supported.")
+                raise NotImplementedError(f"PCA encoding by '{encoding}' is not supported.")
 
             genomes_df.columns = [
                 "Site " + str(k)

--- a/tests/pathogen-embed-pca-encoding-by-biallelic.t
+++ b/tests/pathogen-embed-pca-encoding-by-biallelic.t
@@ -1,0 +1,28 @@
+Run pathogen-embed with PCA on a H3N2 HA alignment using the default "integer" encoding.
+
+  $ pathogen-embed \
+  >   --alignment $TESTDIR/data/h3n2_ha_alignment.fasta \
+  >   --output-dataframe embed_pca_integer.csv \
+  >   pca \
+  >   --components 2 \
+  >   --encoding integer
+
+Run pathogen-embed with PCA on a H3N2 HA alignment using the "biallelic" encoding.
+
+  $ pathogen-embed \
+  >   --alignment $TESTDIR/data/h3n2_ha_alignment.fasta \
+  >   --output-dataframe embed_pca_biallelic.csv \
+  >   pca \
+  >   --components 2 \
+  >   --encoding biallelic
+
+There should be one record in the embedding per input sequence in the alignment.
+
+  $ [[ $(sed 1d embed_pca_integer.csv | wc -l) == $(grep "^>" $TESTDIR/data/h3n2_ha_alignment.fasta | wc -l) ]]
+  $ [[ $(sed 1d embed_pca_biallelic.csv | wc -l) == $(grep "^>" $TESTDIR/data/h3n2_ha_alignment.fasta | wc -l) ]]
+
+The two PCA outputs should differ because of their different input encoding.
+
+  $ diff -q embed_pca_integer.csv embed_pca_biallelic.csv
+  Files embed_pca_integer.csv and embed_pca_biallelic.csv differ
+  [1]

--- a/tests/pathogen-embed-pca-encoding-by-genotype.t
+++ b/tests/pathogen-embed-pca-encoding-by-genotype.t
@@ -1,0 +1,28 @@
+Run pathogen-embed with PCA on a H3N2 HA alignment using the default "integer" encoding.
+
+  $ pathogen-embed \
+  >   --alignment $TESTDIR/data/h3n2_ha_alignment.fasta \
+  >   --output-dataframe embed_pca_integer.csv \
+  >   pca \
+  >   --components 2 \
+  >   --encoding integer
+
+Run pathogen-embed with PCA on a H3N2 HA alignment using the "genotype" encoding.
+
+  $ pathogen-embed \
+  >   --alignment $TESTDIR/data/h3n2_ha_alignment.fasta \
+  >   --output-dataframe embed_pca_genotype.csv \
+  >   pca \
+  >   --components 2 \
+  >   --encoding genotype
+
+There should be one record in the embedding per input sequence in the alignment.
+
+  $ [[ $(sed 1d embed_pca_integer.csv | wc -l) == $(grep "^>" $TESTDIR/data/h3n2_ha_alignment.fasta | wc -l) ]]
+  $ [[ $(sed 1d embed_pca_genotype.csv | wc -l) == $(grep "^>" $TESTDIR/data/h3n2_ha_alignment.fasta | wc -l) ]]
+
+The two PCA outputs should differ because of their different input encoding.
+
+  $ diff -q embed_pca_integer.csv embed_pca_genotype.csv
+  Files embed_pca_integer.csv and embed_pca_genotype.csv differ
+  [1]

--- a/tests/pathogen-embed-pca-encoding-by-simplex.t
+++ b/tests/pathogen-embed-pca-encoding-by-simplex.t
@@ -1,0 +1,28 @@
+Run pathogen-embed with PCA on a H3N2 HA alignment using the default "integer" encoding.
+
+  $ pathogen-embed \
+  >   --alignment $TESTDIR/data/h3n2_ha_alignment.fasta \
+  >   --output-dataframe embed_pca_integer.csv \
+  >   pca \
+  >   --components 2 \
+  >   --encoding integer
+
+Run pathogen-embed with PCA on a H3N2 HA alignment using the "simplex" encoding.
+
+  $ pathogen-embed \
+  >   --alignment $TESTDIR/data/h3n2_ha_alignment.fasta \
+  >   --output-dataframe embed_pca_simplex.csv \
+  >   pca \
+  >   --components 2 \
+  >   --encoding simplex
+
+There should be one record in the embedding per input sequence in the alignment.
+
+  $ [[ $(sed 1d embed_pca_integer.csv | wc -l) == $(grep "^>" $TESTDIR/data/h3n2_ha_alignment.fasta | wc -l) ]]
+  $ [[ $(sed 1d embed_pca_simplex.csv | wc -l) == $(grep "^>" $TESTDIR/data/h3n2_ha_alignment.fasta | wc -l) ]]
+
+The two PCA outputs should differ because of their different input encoding.
+
+  $ diff -q embed_pca_integer.csv embed_pca_simplex.csv
+  Files embed_pca_integer.csv and embed_pca_simplex.csv differ
+  [1]


### PR DESCRIPTION
Adds alternate encodings of sequences for PCA inputs including:

- genotype binary encoding for all alleles (N x 4L) also referred to as one-hot encoding (e.g., “A” is represented as `[1, 0, 0, 0]`, “C” as `[0, 1, 0, 0]`, etc.)
- simplex encoding (N x 3L) based on [Stormo 2011](https://academic.oup.com/genetics/article/187/4/1219/6063441) (e.g., “A” is represented as `[1, -1, -1]`, “C” as `[-1, 1, -1]`, etc.)
- biallelic genotype binary encoding (N x L_b for b biallelic sites) following the [McVean 2008](https://journals.plos.org/plosgenetics/article?id=10.1371/journal.pgen.1000686) approach used for human genomics (the first sequence in the alignment defines the “reference” allele at each site with an encoding of 0 while the alternate allele is encoded as 1)

Names the original encoding as "integer", since that encoding maps each ACGT to an integer (1, 2, 3, 4) and any other characters to 5. The default encoding remains "integer", so this change is backward compatible. However, initial tests suggest that the simplex encoding may be a better default.

Closes #22 