### PR TITLE
Use inferred types for external embedding params

### DIFF
--- a/src/pathogen_embed/pathogen_embed.py
+++ b/src/pathogen_embed/pathogen_embed.py
@@ -555,12 +555,11 @@ def embed(args):
     if external_embedding_parameters is not None and args.command != "pca":
         for key, value in external_embedding_parameters.items():
             if key in embedding_parameters:
-                value_type = type(embedding_parameters[key])
                 print(
-                    f"INFO: Replacing embedding parameter {key} value of '{embedding_parameters[key]}' with '{value_type(value)}' provided by '{args.embedding_parameters}'.",
+                    f"INFO: Replacing embedding parameter {key} value of '{embedding_parameters[key]}' with '{value}' provided by '{args.embedding_parameters}'.",
                     file=sys.stderr
                 )
-                embedding_parameters[key] = value_type(value)
+                embedding_parameters[key] = value
 
     if args.command != "pca":
         #TODO: distance matrices are no longer symmetrics/not square? Check into this

--- a/tests/data/h3n2_ha_t-sne_parameters.csv
+++ b/tests/data/h3n2_ha_t-sne_parameters.csv
@@ -1,0 +1,2 @@
+method,perplexity,learning_rate,mae,virus,recombination_rate
+t-sne,45.0,100.0,10.232042200393089,influenza,no-reassortment

--- a/tests/pathogen-embed-t-sne-params-file.t
+++ b/tests/pathogen-embed-t-sne-params-file.t
@@ -1,0 +1,14 @@
+Run pathogen-embed with t-SNE on a H3N2 HA alignment with parameters loaded from a file.
+This should print changes from the defaults to the parameters in the file to the screen.
+
+  $ pathogen-embed \
+  >   --alignment $TESTDIR/data/h3n2_ha_alignment.fasta \
+  >   --embedding-parameters $TESTDIR/data/h3n2_ha_t-sne_parameters.csv \
+  >   --output-dataframe embed_t-sne.csv \
+  >   t-sne
+  INFO: Replacing embedding parameter perplexity value of '30.0' with '45.0' provided by '(.*)'. (re)
+  INFO: Replacing embedding parameter learning_rate value of 'auto' with '100.0' provided by '(.*)'. (re)
+
+There should be one record in the embedding per input sequence in the alignment.
+
+  $ [[ $(sed 1d embed_t-sne.csv | wc -l) == $(grep "^>" $TESTDIR/data/h3n2_ha_alignment.fasta | wc -l) ]]


### PR DESCRIPTION
Fixes a bug that happens when setting the t-SNE learning rate parameter with an external file. The internal logic of the embedding script tries to cast the external value file to the same type as the default value of each embedding method's arguments. For example, the default perplexity has a type of `float`, so the logic converts the input file's value to a `float` even if it appears in the file as an integer. This logic fails when setting t-SNE's learning rate parameter which has a default value of "auto" (a string) but which also accepts `float` values. The logic casts any valid `float` to a string and passes that string to the scikit-learn t-SNE class which throws a type error.

This commit fixes the bug by removing the custom logic to cast types from the external parameters file and allowing the default type inference from pandas to set the correct type. This way, if the user defines a learning rate of "auto" in the CSV input, it will be parsed as a string. If the user defines a `float` like 100.0, it will be parsed as a `float`. If the user defines any other type like 100, the script will throw an error.