### PR TITLE
Automatically pick SVD algorithm for PCA from data

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,13 @@
 # CHANGELOG
 
+## 2.2.1
+
+### Bug Fixes
+
+* Let scikit-learn automatically pick SVD algorithm to use for PCA instead of hardcoding the "full" solver ([#31][])
+
+[#31]: https://github.com/blab/pathogen-embed/pull/31
+
 ## 2.2.0
 
 ### Features

--- a/src/pathogen_embed/pathogen_embed.py
+++ b/src/pathogen_embed/pathogen_embed.py
@@ -509,7 +509,7 @@ def embed(args):
         #performing PCA on my pandas dataframe
         pca = PCA(
             n_components=n_components,
-            svd_solver='full',
+            svd_solver='auto',
             random_state=args.random_seed,
         )
         principalComponents = pca.fit_transform(genomes_df)


### PR DESCRIPTION
Let scikit-learn automatically pick the SVD algorithm to use for PCA based on the given data instead of hardcoding the "full" solver. Fixes a bug that can occur with random virus datasets where the full SVD solver cannot converge but the randomized solver can. The scikit-learn PCA class picks from the full, arpack, and randomized solvers based on the shape of the input data matrix [1] which makes PCA more robust to these kinds of convergence issues.

[1] https://scikit-learn.org/stable/modules/generated/sklearn.decomposition.PCA.html#pca