### PR TITLE
Replace internal sorting with check for order

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,9 +4,11 @@
 
 ### Bug Fixes
 
+* Do not internally sort embedding inputs by sequence name ([#32][])
 * Let scikit-learn automatically pick SVD algorithm to use for PCA instead of hardcoding the "full" solver ([#31][])
 
 [#31]: https://github.com/blab/pathogen-embed/pull/31
+[#32]: https://github.com/blab/pathogen-embed/pull/32
 
 ## 2.2.0
 

--- a/README.md
+++ b/README.md
@@ -93,14 +93,16 @@ The clusters in the resulting embedding represent genetic diversity in each gene
 The following example shows how to apply this approach to alignments for seasonal influenza A/H3N2 HA and NA.
 
 Calculate a separate distance matrix per gene alignment for HA and NA.
+Note that alignments must have the same sequence names in the same order.
+If they do not, sort your alignments by sequence name with a tool like [seqkit](https://bioinf.shenwei.me/seqkit/) first (e.g., `seqkit sort -n alignment.fasta > alignment.sorted.fasta`).
 
 ```bash
 pathogen-distance \
-  --alignment tests/data/h3n2_ha_alignment.fasta \
+  --alignment tests/data/h3n2_ha_alignment.sorted.fasta \
   --output ha_distances.csv
 
 pathogen-distance \
-  --alignment tests/data/h3n2_na_alignment.fasta \
+  --alignment tests/data/h3n2_na_alignment.sorted.fasta \
   --output na_distances.csv
 ```
 
@@ -109,7 +111,7 @@ The t-SNE embedding gets initialized by a PCA embedding from the alignments.
 
 ```bash
 pathogen-embed \
-  --alignment tests/data/h3n2_ha_alignment.fasta tests/data/h3n2_na_alignment.fasta \
+  --alignment tests/data/h3n2_ha_alignment.sorted.fasta tests/data/h3n2_na_alignment.sorted.fasta \
   --distance-matrix ha_distances.csv na_distances.csv \
   --output-dataframe tsne.csv \
   --output-figure tsne.pdf \

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ with open("README.md", "r", encoding="utf-8") as fh:
 
 setup(
     name='pathogen-embed',
-    version='2.2.0',
+    version='2.2.1',
     description='Reduced dimension embeddings for pathogen sequences',
     url='https://github.com/blab/pathogen-embed/',
     author='Sravani Nanduri <nandsra@cs.washington.edu> , John Huddleston <huddlej@gmail.com>',

--- a/src/pathogen_embed/pathogen_embed.py
+++ b/src/pathogen_embed/pathogen_embed.py
@@ -81,7 +81,7 @@ def encode_alignment_for_pca_by_integer(alignment_path):
     for sequence in Bio.SeqIO.parse(alignment_path, "fasta"):
         sequences_by_name[sequence.id] = str(sequence.seq)
 
-    sequence_names = sorted(list(sequences_by_name.keys()))
+    sequence_names = list(sequences_by_name.keys())
     numbers = []
     for sequence_name in sequence_names:
         sequence = sequences_by_name[sequence_name]
@@ -121,7 +121,7 @@ def encode_alignment_for_pca_by_genotype(alignment_path):
     for sequence in Bio.SeqIO.parse(alignment_path, "fasta"):
         sequences_by_name[sequence.id] = str(sequence.seq)
 
-    sequence_names = sorted(list(sequences_by_name.keys()))
+    sequence_names = list(sequences_by_name.keys())
     numbers = []
     for sequence_name in sequence_names:
         sequence = sequences_by_name[sequence_name]
@@ -169,7 +169,7 @@ def encode_alignment_for_pca_by_simplex(alignment_path):
     for sequence in Bio.SeqIO.parse(alignment_path, "fasta"):
         sequences_by_name[sequence.id] = str(sequence.seq)
 
-    sequence_names = sorted(list(sequences_by_name.keys()))
+    sequence_names = list(sequences_by_name.keys())
     numbers = []
     for sequence_name in sequence_names:
         sequence = sequences_by_name[sequence_name]
@@ -231,7 +231,7 @@ def encode_alignment_for_pca_by_biallelic(alignment_path):
     genomes_df = pd.DataFrame(
         numbers,
         index=sequence_names,
-    ).astype(np.int8).sort_index()
+    ).astype(np.int8)
 
     return genomes_df
 
@@ -384,14 +384,14 @@ def embed(args):
     distance_matrix = None
     if args.distance_matrix is not None and args.command != "pca":
         distance_path = args.distance_matrix[0]
-        distance_df = pd.read_csv(distance_path, index_col=0).sort_index(axis=0).sort_index(axis=1)
+        distance_df = pd.read_csv(distance_path, index_col=0)
         distance_array = distance_df.values.astype(float)
 
         # Add the numpy arrays element-wise
         for distance_path in args.distance_matrix[1:]:
-            other_distance_df = pd.read_csv(distance_path, index_col=0).sort_index(axis=0).sort_index(axis=1)
+            other_distance_df = pd.read_csv(distance_path, index_col=0)
             if not np.array_equal(distance_df.index.values, other_distance_df.index.values):
-                print("ERROR: The given distance matrices do not have the same sequence names.", file=sys.stderr)
+                print("ERROR: The given distance matrices do not have the same sequence names in the same order.", file=sys.stderr)
                 sys.exit(1)
 
             other_distance_array = other_distance_df.values.astype(float)
@@ -408,16 +408,10 @@ def embed(args):
     # the method, calculate distances on the fly.
     if args.alignment is not None and distance_matrix is None and (args.command != "pca" or args.output_pairwise_distance_figure):
         for alignment in args.alignment:
-            # Calculate a distance matrix on the fly and sort the matrix
-            # alphabetically by sequence name, so we can safely sum values
-            # across all inputs.
+            # Calculate a distance matrix on the fly.
             new_distance_matrix = calculate_distances_from_alignment(
                 alignment,
                 args.indel_distance,
-            ).sort_index(
-                axis=0,
-            ).sort_index(
-                axis=1,
             )
 
             if distance_matrix is None:
@@ -429,7 +423,7 @@ def embed(args):
                     new_distance_matrix.index.values,
                     distance_matrix.index.values,
                 ):
-                    print("ERROR: The given alignments do not have the same sequence names.", file=sys.stderr)
+                    print("ERROR: The given alignments do not have the same sequence names in the same order. Confirm your alignments have the same sequence names and sort your alignments (e.g., `seqkit sort -n alignment.fasta > sorted_alignment.fasta`) so they have the same order.", file=sys.stderr)
                     sys.exit(1)
 
                 distance_matrix += new_distance_matrix
@@ -488,7 +482,7 @@ def embed(args):
             )
         )
         if not all_alignments_have_same_sequence_names:
-            print("ERROR: The given alignments do not have the same sequence names.", file=sys.stderr)
+            print("ERROR: The given alignments do not have the same sequence names in the same order. Confirm your alignments have the same sequence names and sort your alignments (e.g., `seqkit sort -n alignment.fasta > sorted_alignment.fasta`) so they have the same order.", file=sys.stderr)
             sys.exit(1)
 
         # Combine matrix encodings for all alignments, after confirming that

--- a/tests/pathogen-embed-mds-multiple-alignments-with-different-samples.t
+++ b/tests/pathogen-embed-mds-multiple-alignments-with-different-samples.t
@@ -10,5 +10,5 @@ This should fail.
   >   --alignment h3n2_ha_alignment.fasta h3n2_na_alignment.fasta \
   >   --output-dataframe embed_mds.csv \
   >   mds
-  ERROR: The given alignments do not have the same sequence names.
+  ERROR: The given alignments do not have the same sequence names in the same order. Confirm your alignments have the same sequence names and sort your alignments (e.g., `seqkit sort -n alignment.fasta > sorted_alignment.fasta`) so they have the same order.
   [1]

--- a/tests/pathogen-embed-mds-multiple-alignments.t
+++ b/tests/pathogen-embed-mds-multiple-alignments.t
@@ -1,21 +1,11 @@
 Run pathogen-embed with MDS on a H3N2 HA and H3N2 NA alignments such that distance matrices get calculated on the fly.
 
   $ pathogen-embed \
-  >   --alignment $TESTDIR/data/h3n2_ha_alignment.fasta $TESTDIR/data/h3n2_na_alignment.fasta \
+  >   --alignment $TESTDIR/data/h3n2_ha_alignment.sorted.fasta $TESTDIR/data/h3n2_na_alignment.sorted.fasta \
   >   --output-dataframe embed_mds.csv \
   >   mds \
   >   --components 2
 
 There should be one record in the embedding per input sequence in the alignment.
 
-  $ [[ $(sed 1d embed_mds.csv | wc -l) == $(grep "^>" $TESTDIR/data/h3n2_ha_alignment.fasta | wc -l) ]]
-
-Repeat the embedding with sorted alignment inputs.
-The resulting embeddings should be identical, since the script should internally sort distance matrices by sequence names.
-
-  $ pathogen-embed \
-  >   --alignment $TESTDIR/data/h3n2_ha_alignment.sorted.fasta $TESTDIR/data/h3n2_na_alignment.sorted.fasta \
-  >   --output-dataframe embed_mds_sorted.csv \
-  >   mds \
-  >   --components 2
-  $ diff -u embed_mds.csv embed_mds_sorted.csv
+  $ [[ $(sed 1d embed_mds.csv | wc -l) == $(grep "^>" $TESTDIR/data/h3n2_ha_alignment.sorted.fasta | wc -l) ]]

--- a/tests/pathogen-embed-mds-multiple-distances-with-different-samples.t
+++ b/tests/pathogen-embed-mds-multiple-distances-with-different-samples.t
@@ -21,5 +21,5 @@ Run pathogen-embed with MDS on mismatched distances with different samples.
   >   --output-dataframe embed_mds.csv \
   >   mds \
   >   --components 2
-  ERROR: The given distance matrices do not have the same sequence names.
+  ERROR: The given distance matrices do not have the same sequence names in the same order.
   [1]

--- a/tests/pathogen-embed-mds-multiple-distances.t
+++ b/tests/pathogen-embed-mds-multiple-distances.t
@@ -1,13 +1,13 @@
 Get a distance matrix from a H3N2 HA alignment.
 
   $ pathogen-distance \
-  >   --alignment $TESTDIR/data/h3n2_ha_alignment.fasta \
+  >   --alignment $TESTDIR/data/h3n2_ha_alignment.sorted.fasta \
   >   --output ha_distances.csv
 
 Get a distance matrix from a H3N2 NA alignment.
 
   $ pathogen-distance \
-  >   --alignment $TESTDIR/data/h3n2_na_alignment.fasta \
+  >   --alignment $TESTDIR/data/h3n2_na_alignment.sorted.fasta \
   >   --output na_distances.csv
 
 Run pathogen-embed with MDS on distances from H3N2 HA and H3N2 NA alignments.
@@ -20,7 +20,7 @@ Run pathogen-embed with MDS on distances from H3N2 HA and H3N2 NA alignments.
 
 There should be one record in the embedding per input sequence in the alignment.
 
-  $ [[ $(sed 1d embed_mds.csv | wc -l) == $(grep "^>" $TESTDIR/data/h3n2_ha_alignment.fasta | wc -l) ]]
+  $ [[ $(sed 1d embed_mds.csv | wc -l) == $(grep "^>" $TESTDIR/data/h3n2_ha_alignment.sorted.fasta | wc -l) ]]
 
 The order of records in the embedding should be alphabetically sorted and contain the same sequence names as the input distances.
 

--- a/tests/pathogen-embed-pca-multiple-alignments-with-different-samples.t
+++ b/tests/pathogen-embed-pca-multiple-alignments-with-different-samples.t
@@ -9,5 +9,5 @@ Run pathogen-embed with PCA on a H3N2 HA and H3N2 NA alignments.
   >   --alignment h3n2_ha_alignment.fasta h3n2_na_alignment.fasta \
   >   --output-dataframe embed_pca.csv \
   >   pca
-  ERROR: The given alignments do not have the same sequence names.
+  ERROR: The given alignments do not have the same sequence names in the same order. Confirm your alignments have the same sequence names and sort your alignments (e.g., `seqkit sort -n alignment.fasta > sorted_alignment.fasta`) so they have the same order.
   [1]

--- a/tests/pathogen-embed-pca-multiple-alignments-with-unsorted-samples.t
+++ b/tests/pathogen-embed-pca-multiple-alignments-with-unsorted-samples.t
@@ -1,19 +1,10 @@
 Run pathogen-embed with PCA on a H3N2 HA and H3N2 NA alignments with sequence names in a different order in each file.
+This should cause an error explaining how to properly sort alignments prior to the embedding.
 
   $ pathogen-embed \
   >   --alignment $TESTDIR/data/h3n2_ha_alignment.fasta $TESTDIR/data/h3n2_na_alignment.fasta \
   >   --output-dataframe embed_pca_unsorted.csv \
   >   pca \
   >    --components 2
-
-Run PCA again but with alignments with sequence names in the same order in each file.
-
-  $ pathogen-embed \
-  >   --alignment $TESTDIR/data/h3n2_ha_alignment.sorted.fasta $TESTDIR/data/h3n2_na_alignment.sorted.fasta \
-  >   --output-dataframe embed_pca_sorted.csv \
-  >   pca \
-  >    --components 2
-
-The two PCA embeddings should be identical regardless of the sorting of sequences in the input alignments.
-
-  $ diff -u embed_pca_unsorted.csv embed_pca_sorted.csv
+  ERROR: The given alignments do not have the same sequence names in the same order. Confirm your alignments have the same sequence names and sort your alignments (e.g., `seqkit sort -n alignment.fasta > sorted_alignment.fasta`) so they have the same order.
+  [1]

--- a/tests/pathogen-embed-pca-multiple-alignments.t
+++ b/tests/pathogen-embed-pca-multiple-alignments.t
@@ -1,7 +1,7 @@
 Run pathogen-embed with PCA on a H3N2 HA and H3N2 NA alignments.
 
   $ pathogen-embed \
-  >   --alignment $TESTDIR/data/h3n2_ha_alignment.fasta $TESTDIR/data/h3n2_na_alignment.fasta \
+  >   --alignment $TESTDIR/data/h3n2_ha_alignment.sorted.fasta $TESTDIR/data/h3n2_na_alignment.sorted.fasta \
   >   --output-dataframe embed_pca.csv \
   >   pca \
   >   --components 2 \
@@ -9,7 +9,7 @@ Run pathogen-embed with PCA on a H3N2 HA and H3N2 NA alignments.
 
 There should be one record in the embedding per input sequence in the alignment.
 
-  $ [[ $(sed 1d embed_pca.csv | wc -l) == $(grep "^>" $TESTDIR/data/h3n2_ha_alignment.fasta | wc -l) ]]
+  $ [[ $(sed 1d embed_pca.csv | wc -l) == $(grep "^>" $TESTDIR/data/h3n2_ha_alignment.sorted.fasta | wc -l) ]]
 
 There should be 2 components of variance explained.
 

--- a/tests/pathogen-embed-t-sne-multiple-distances-and-alignments.t
+++ b/tests/pathogen-embed-t-sne-multiple-distances-and-alignments.t
@@ -1,19 +1,19 @@
 Get a distance matrix from a H3N2 HA alignment.
 
   $ pathogen-distance \
-  >   --alignment $TESTDIR/data/h3n2_ha_alignment.fasta \
+  >   --alignment $TESTDIR/data/h3n2_ha_alignment.sorted.fasta \
   >   --output ha_distances.csv
 
 Get a distance matrix from a H3N2 NA alignment.
 
   $ pathogen-distance \
-  >   --alignment $TESTDIR/data/h3n2_na_alignment.fasta \
+  >   --alignment $TESTDIR/data/h3n2_na_alignment.sorted.fasta \
   >   --output na_distances.csv
 
 Run pathogen-embed with t-SNE on distances from H3N2 HA and H3N2 NA alignments.
 
   $ pathogen-embed \
-  >   --alignment $TESTDIR/data/h3n2_ha_alignment.fasta $TESTDIR/data/h3n2_na_alignment.fasta \
+  >   --alignment $TESTDIR/data/h3n2_ha_alignment.sorted.fasta $TESTDIR/data/h3n2_na_alignment.sorted.fasta \
   >   --distance-matrix ha_distances.csv na_distances.csv \
   >   --output-dataframe embed_t-sne.csv \
   >   --output-figure embed_t-sne.pdf \
@@ -22,4 +22,4 @@ Run pathogen-embed with t-SNE on distances from H3N2 HA and H3N2 NA alignments.
 
 There should be one record in the embedding per input sequence in the alignment.
 
-  $ [[ $(sed 1d embed_t-sne.csv | wc -l) == $(grep "^>" $TESTDIR/data/h3n2_ha_alignment.fasta | wc -l) ]]
+  $ [[ $(sed 1d embed_t-sne.csv | wc -l) == $(grep "^>" $TESTDIR/data/h3n2_ha_alignment.sorted.fasta | wc -l) ]]


### PR DESCRIPTION
Replace internal sort of alignments and distance matrices with a check for consistent record order across inputs. Fixes bugs caused by unexpected mismatch between inputs to and outputs from pathogen-embed. For example, pathogen-distance produces a matrix output with sequence names in the same order as the input, but pathogen-embed would produce an embedding ordered alphabetically by sequence name. This commit opts for an alternate approach of checking for the same order in multiple alignment or distance matrix inputs and throwing an error when mismatches are found.

Closes #28